### PR TITLE
Automerge minor and group micronaut packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,9 @@
   "major": {
     "automerge": false
   },
+  "minor": {
+    "automerge": true
+  },
   "masterIssue": true,
   "masterIssueAutoclose": true,
   "packageRules": [
@@ -106,6 +109,12 @@
         "^org.apache.kafka"
       ],
       "groupName": "apache kafka packages"
+    },
+    {
+      "packagePatterns": [
+        "^io.micronaut"
+      ],
+      "groupName": "micronaut packages"
     }
   ],
   "pin": {


### PR DESCRIPTION
Stemmer for at vi skrur på automerge for minor versjoner, slik det er nå så gjøres det uansett ikke noe ekstra testing om PRen bygger grønt. 

Har også lagt til en gruppering på micronaut pakker, fordi parameter-store dependencien som kom inn etter micronaut 2.0 nå har startet å bli oppdatert for seg selv
