### PR TITLE
Turn off automerge for kotlin packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -85,7 +85,13 @@
         "^org.jetbrains.kotlin."
       ],
       "groupName": "jetbrain kotlin packages",
-      "automerge": false
+      "minor": {
+        "automerge": false
+      },
+      "patch": {
+        "automerge": true
+      },
+      "separateMinorPatch": true
     },
     {
       "packagePatterns": [

--- a/default.json
+++ b/default.json
@@ -84,7 +84,8 @@
       "packagePatterns": [
         "^org.jetbrains.kotlin."
       ],
-      "groupName": "jetbrain kotlin packages"
+      "groupName": "jetbrain kotlin packages",
+      "automerge": false
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
Skrur av automerge for kotlin versjon, siden disse kan inneholde breaking changes