### PR TITLE
Limit renovate to running once a week

### DIFF
--- a/default.json
+++ b/default.json
@@ -125,7 +125,7 @@
     "automerge": true
   },
   "prCreation": "not-pending",
-  "schedule": ["before 6am", "every weekend"],
+  "schedule": ["before 6am on Monday"],
   "semanticCommits": true,
   "stabilityDays": 3,
   "prNotPendingHours": 74,


### PR DESCRIPTION
For å redusere støy fra renovate så kan vi konfigurere den til kun å kjøre en gang i uken, f.eks. mandag morgener. Tidligere var den konfigurert til å kjøre hver dag før 06.00 og i alle helger.

